### PR TITLE
Improvements and fixes

### DIFF
--- a/src/Our.Umbraco.HealthChecks/Checks/Media/MediaIntegrityCheck.cs
+++ b/src/Our.Umbraco.HealthChecks/Checks/Media/MediaIntegrityCheck.cs
@@ -67,7 +67,7 @@ namespace Our.Umbraco.HealthChecks.Checks.Media
                     // \/[M|m]edia\/[0-9]+\/([^']+)
                     // This regex pattern will match the media path within the umbracoFile entry in the examine search {src: '/media/1050/myimage.jpg', crops: []}
                     // In the above example /media/1050/myimage.jpg will be extracted from the entry
-                    mediaItems.Add(Regex.Match(itemResult.Fields["umbracoFile"], @"[M|m]edia\/[0-9]+\/([^']+)").Value);
+                    mediaItems.Add(Regex.Match(itemResult.Fields["umbracoFile"], @"[M|m]edia\/[0-9]+\/([^'|""]+)").Value);
                 }
 
                 return mediaItems;

--- a/src/Our.Umbraco.HealthChecks/Checks/Media/MediaIntegrityCheck.cs
+++ b/src/Our.Umbraco.HealthChecks/Checks/Media/MediaIntegrityCheck.cs
@@ -11,6 +11,7 @@ using Umbraco.Core.Configuration;
 using Umbraco.Core.IO;
 using Umbraco.Core.Persistence;
 using Umbraco.Core.Services;
+using Umbraco.Web;
 using Umbraco.Web.HealthCheck;
 using Umbraco.Web.PublishedCache;
 
@@ -38,7 +39,8 @@ namespace Our.Umbraco.HealthChecks.Checks.Media
             _db = healthCheckContext.ApplicationContext.DatabaseContext.Database;
             _umbracoVersion = UmbracoVersion.Current;
             _mediaService = healthCheckContext.ApplicationContext.Services.MediaService;
-            _umbracoCache = healthCheckContext.UmbracoContext.ContentCache;
+            _umbracoCache = UmbracoContext.Current.ContentCache;
+
             _webRoot = IOHelper.MapPath("/");
             _internalIndex = ExamineManager.Instance.SearchProviderCollection["InternalSearcher"];
         }
@@ -56,7 +58,7 @@ namespace Our.Umbraco.HealthChecks.Checks.Media
         {
             HashSet<string> mediaItems = new HashSet<string>();
             var searchCriteria = _internalIndex.CreateSearchCriteria();
-            var query = searchCriteria.RawQuery("+__IndexType:media");
+            var query = searchCriteria.RawQuery("+__IndexType:media +__Icon: icon-picture");
             var searchResults = _internalIndex.Search(query);
             if (searchResults.Any())
             {


### PR DESCRIPTION
Removed Xpath when used on sites with more content its less efficient, as I have to use a query that is very obscure as I don't know the names of the nodes I am searching for. 

Getting the XML as a string and performing a regex query seems to get the job done a lot faster without prolonged High CPU usage.

New problem discovered some items may be created but not have any files uploaded to them so we ensure this key "umbracoFile" is set in the examine results and count the ones that don't have umbracoFile key.