### PR TITLE
Add Url Picker Pre Production Domain Health Check

### DIFF
--- a/src/Our.Umbraco.HealthChecks/Checks/Data/UrlDomainHealthcheck.cs
+++ b/src/Our.Umbraco.HealthChecks/Checks/Data/UrlDomainHealthcheck.cs
@@ -1,0 +1,166 @@
+﻿using Our.Umbraco.Healthchecks.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+using System.Configuration;
+using Umbraco.Web.HealthCheck;
+using Umbraco.Core.Persistence;
+
+namespace Our.Umbraco.Healthchecks
+{
+    [HealthCheck(
+          "de366476-8e6e-4c72-9b29-71294df9d7e3",
+          "Pre-Production Url Picker Domains",
+          Description = "Checks the database for hardcoded references to 'pre-production' domains in Url Picked properties. Defaults to look for localhost, configure domains to look for via appsetting: Our.Umbraco.Healthchecks.UrlPickerDomains",
+          Group = "Data")]
+    public class UrlPickerDomainsHealthCheck : HealthCheck
+    {
+        private readonly UmbracoDatabase _db;
+
+
+        public UrlPickerDomainsHealthCheck(HealthCheckContext healthCheckContext) : base(healthCheckContext)
+        {
+            _db = healthCheckContext.ApplicationContext.DatabaseContext.Database;
+        }
+        public override IEnumerable<HealthCheckStatus> GetStatus()
+        {
+            var statusesToCheck = new List<HealthCheckStatus>();
+            //TODO: should default to localhost
+            var domainListToCheck = "localhost";
+            if (ConfigurationManager.AppSettings.AllKeys.Contains("Our.Umbraco.Healthchecks.UrlPickerDomains"))
+            {
+                domainListToCheck = ConfigurationManager.AppSettings["Our.Umbraco.Healthchecks.UrlPickerDomains"];
+            }
+            //check for multiple domains
+            var domainsToCheck = domainListToCheck.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            //read in config value split on comma
+            //foreach adn add checkfordomain for each one.
+            foreach (var domain in domainsToCheck) {
+                statusesToCheck.Add(CheckForDomain(domain));
+            }
+            return statusesToCheck;
+        }
+        private string HighlightMatch(string data, string domain)
+        {
+            string snippet = String.Empty;
+            if (String.IsNullOrEmpty(data))
+            {
+                return String.Empty;
+            }
+            //TODO: what if the domain is mentioned more than once in the string?
+
+            var matchPosition = data.IndexOf(domain);
+            if (matchPosition > -1)
+            {
+                var startSnippetPos = matchPosition > 30 ? matchPosition - 30 : 0;
+                var remainingData = data.Length - matchPosition - domain.Length;
+                var snippetLength = remainingData <= 30 ? domain.Length : domain.Length + 60;
+                snippet = data.Substring(startSnippetPos, snippetLength);
+            }
+            return snippet.Replace(domain, "<b>" + domain + "</b>");
+
+        }
+        private HealthCheckStatus CheckForDomain(string domain)
+        {
+            StringBuilder resultMessage = new StringBuilder();
+            StatusResultType resultType = StatusResultType.Info;
+            var actions = new List<HealthCheckAction>();
+            var propertyDataEntries = _db.Query<PropertyDataDetails>("SELECT umbracoNode.id, umbracoNode.[Text], cmsPropertyType.alias, published, updateDate, dataNvarchar, dataNText FROM cmsPropertyData INNER JOIN cmsPropertyType On cmsPropertyType.Id = cmsPropertyData.propertytypeid INNER JOIN UmbracoNode on umbracoNode.Id = cmsPropertyData.contentNodeId INNER JOIN cmsDocument on cmsDocument.versionID = cmsPropertyData.versionId WHERE (dataNtext is not null or dataNvarchar is not null) AND (dataNtext like @0 OR dataNvarchar LIKE @0)", "%" + domain + "%");
+            //var propertyDataEntries = _db.Query<PropertyDataDetails>("SELECT umbracoNode.id, umbracoNode.[Text], cmsPropertyType.alias, published, updateDate, dataNvarchar, dataNText FROM cmsPropertyData INNER JOIN cmsPropertyType On cmsPropertyType.Id = cmsPropertyData.propertytypeid INNER JOIN UmbracoNode on umbracoNode.Id = cmsPropertyData.contentNodeId INNER JOIN cmsDocument on cmsDocument.versionID = cmsPropertyData.versionId WHERE (dataNtext is not null or dataNvarchar is not null) AND (dataNtext like '%moriyama%' OR dataNvarchar LIKE '%moriyama%')");
+            if (propertyDataEntries != null && propertyDataEntries.Any())
+            {
+                resultType = StatusResultType.Error;
+                resultMessage.AppendLine("There are " + propertyDataEntries.Count() + " references to '" + domain + "' in property data");
+                resultMessage.AppendLine("<p><a href='/umbraco/backoffice/api/UrlDomainReport/PropertyDataInstances?domain=" + domain + "'>Full Report</a>: /umbraco/backoffice/api/UrlDomainReport/PropertyDataInstances?domain=" + domain + "</p>");
+                resultMessage.AppendLine("<table>");
+                resultMessage.AppendLine("<tr><th>id</th><th>Name</th><th>Alias</th><th>published</th><th>updated</th><th>Data</th></tr>");
+                foreach (var propertyDataEntry in propertyDataEntries.Where(f => f.published).OrderByDescending(f => f.updateDate).Take(20))
+                {
+                    var data = HighlightMatch(propertyDataEntry.dataNText, domain) + HighlightMatch(propertyDataEntry.dataNvarchar, domain);
+                    resultMessage.AppendLine($"<tr><td><a href='/umbraco#/content/content/edit/{propertyDataEntry.id}'>{propertyDataEntry.id}</a></td><td>{propertyDataEntry.text}</td><td>{propertyDataEntry.alias}</td><td>{propertyDataEntry.published}</td><td>{propertyDataEntry.updateDate:dd/MM/yyyy hh:mm}</td><td>{propertyDataEntry.id}</td><td>{data}</td></tr>");
+                    // resultMessage.AppendLine("<br />" + propertyDataEntry.id.ToString());
+                }
+                resultMessage.AppendLine("</table>");
+              
+                // ng-safe-html attribute is stripping out the href!
+                resultMessage.AppendLine("<p><a href='/umbraco/backoffice/api/UrlDomainReport/PropertyDataInstances?domain=" + domain +"'>Full Report</a>: /umbraco/backoffice/api/UrlDomainReport/PropertyDataInstances?domain=" + domain + "</p>");
+
+                // so I tried adding an action... but didn't get far in making the download occur when requesting the api
+                //actions.Add(new HealthCheckAction("downloadPropertyDataReport", Id)
+                //// Override the "Rectify" button name and describe what this action will do
+                //{
+                //    Name = "Full Report",
+                //    Description = "Download full list of PropertyDataDetails",
+                //    ActionParameters = new Dictionary<string, object>()
+                //         {
+                //             { "domain",domain }
+                //         },
+                //    ProvidedValue = domain
+                //});
+                resultMessage.AppendLine("<p>Useful SQL - set hardcoded domains to be relative links:</p>");
+                resultMessage.AppendLine("<p>");
+                resultMessage.AppendLine("UPDATE cmsPropertyData ");
+                resultMessage.AppendLine("SET dataNtext = CAST(replace(CAST(dataNtext as NVarchar(MAX)), 'https://yourdomain.com/', '/') as NText),");
+                resultMessage.AppendLine("dataNvarchar = replace(dataNvarchar, 'https://yourdomain.com/', '/')");
+                resultMessage.AppendLine("WHERE");
+                resultMessage.AppendLine("(dataNtext is not null or dataNvarchar is not null)");
+                resultMessage.AppendLine("AND");
+                resultMessage.AppendLine("(dataNtext like '%https://yourdomain.com/%'");
+                resultMessage.AppendLine("OR dataNvarchar like '%https://yourdomain.com/%')");
+                resultMessage.AppendLine("</p>");
+            }
+            else
+            {
+                resultType = StatusResultType.Success;
+                resultMessage.AppendLine("<p>There are no references to " + domain + " in property data</p>");
+            }
+            return new HealthCheckStatus(resultMessage.ToString())
+            {
+                ResultType = resultType,
+                Actions = actions
+            };
+        }
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            // NO ACTIONS - Tried to get an action to download the report but failed!
+            switch (action.Alias)
+            {
+                case "downloadPropertyDataReport":
+                    // download the report and output to the response?
+                    //umbraco/backoffice/api/UrlDomainReport/PropertyDataInstances?domain=" + action.ProvidedValue);
+                    //using (var client = new WebClient())
+                    //{
+                    //    string domain = action.ProvidedValue.ToUrlSegment();
+                    //    string filename = $"{DateTime.Now:yy-MM-dd}_{domain}_PropertyDataInstances.html";
+                    //    client.DownloadFile("/umbraco/backoffice/api/UrlDomainReport/PropertyDataInstances?domain=" + action.ProvidedValue),filename);
+                    //}
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            var message = new StringBuilder();
+            message.AppendLine("<p>Useful SQL - set hardcoded domains to be relative links:</p>");
+            message.AppendLine("<p>");
+            message.AppendLine("UPDATE cmsPropertyData ");
+            message.AppendLine("SET dataNtext = CAST(replace(CAST(dataNtext as NVarchar(MAX)), 'https://yourdomain.com/', '/') as NText),");
+            message.AppendLine("dataNvarchar = replace(dataNvarchar, 'https://yourdomain.com/', '/')");
+            message.AppendLine("WHERE");
+            message.AppendLine("(dataNtext is not null or dataNvarchar is not null)");
+            message.AppendLine("AND");
+            message.AppendLine("(dataNtext like '%https://yourdomain.com/%'");
+            message.AppendLine("OR dataNvarchar like '%https://yourdomain.com/%')");
+            message.AppendLine("</p>");
+            return
+                new HealthCheckStatus(message.ToString())
+                {
+                    ResultType = StatusResultType.Warning,
+                    Actions = new List<HealthCheckAction>()
+        };
+
+        }
+    }
+
+}

--- a/src/Our.Umbraco.HealthChecks/Controllers/UrlDomainReportController.cs
+++ b/src/Our.Umbraco.HealthChecks/Controllers/UrlDomainReportController.cs
@@ -1,0 +1,58 @@
+﻿using Our.Umbraco.Healthchecks.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Umbraco.Core;
+using Umbraco.Web.WebApi;
+
+namespace Our.Umbraco.Healthchecks.Controllers
+{
+    public class UrlDomainReportController : UmbracoAuthorizedApiController
+    {
+        [HttpGet]
+        public HttpResponseMessage PropertyDataInstances(string domain)
+        {
+            var propertyDataEntries = ApplicationContext.DatabaseContext.Database.Query<PropertyDataDetails>("SELECT umbracoNode.id, umbracoNode.[Text], cmsPropertyType.alias, published, updateDate, dataNvarchar, dataNText FROM cmsPropertyData INNER JOIN cmsPropertyType On cmsPropertyType.Id = cmsPropertyData.propertytypeid INNER JOIN UmbracoNode on umbracoNode.Id = cmsPropertyData.contentNodeId INNER JOIN cmsDocument on cmsDocument.versionID = cmsPropertyData.versionId WHERE (dataNtext is not null or dataNvarchar is not null) AND (dataNtext like @0 OR dataNvarchar LIKE @0)", "%" + domain + "%");
+
+            StringBuilder resultMessage = new StringBuilder();
+            resultMessage.AppendLine("<html><head><title>" + domain + "</title></head><body>");
+            if (propertyDataEntries != null && propertyDataEntries.Any())
+            {
+
+                resultMessage.AppendLine("There are " + propertyDataEntries.Count() + " references to '" + domain + "' in property data");
+                resultMessage.AppendLine("<table>");
+                resultMessage.AppendLine("<tr><th>id</th><th>Name</th><th>Alias</th><th>published</th><th>updated</th><th>Data</th></tr>");
+                foreach (var propertyDataEntry in propertyDataEntries.Where(f => f.published).OrderByDescending(f => f.updateDate).Take(50))
+                {
+                    resultMessage.AppendLine($"<tr><td>{propertyDataEntry.id}</td><td>{propertyDataEntry.text}</td><td>{propertyDataEntry.alias}</td><td>{propertyDataEntry.published}</td><td>{propertyDataEntry.updateDate:dd/MM/yyyy hh:mm}</td><td>{propertyDataEntry.id}</td><td><textarea>{propertyDataEntry.dataNvarchar}{propertyDataEntry.dataNText}</textarea></td></tr>");
+                    // resultMessage.AppendLine("<br />" + propertyDataEntry.id.ToString());
+                }
+                resultMessage.AppendLine("</table>");
+
+            }
+            else
+            {
+                resultMessage.AppendLine("<p>There are no references to " + domain + " in property data</p>");
+            }
+            resultMessage.AppendLine("</body></html>");
+         
+            string filename = $"{DateTime.Now:yy-MM-dd}_{domain.ToUrlSegment()}_PropertyDataInstances.html";
+
+            HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
+
+            result.Content = new StringContent(resultMessage.ToString());
+            result.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
+            result.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+            {
+                FileName = filename
+            };
+            return result;
+        }
+    }
+}

--- a/src/Our.Umbraco.HealthChecks/Models/PropertyDataDetails.cs
+++ b/src/Our.Umbraco.HealthChecks/Models/PropertyDataDetails.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.Healthchecks.Models
+{
+    public class PropertyDataDetails
+    {
+        public int id { get; set; }
+        public string text { get; set; }
+        public string alias { get; set; }
+        public bool published { get; set; }
+        public DateTime updateDate { get; set; }
+        public string dataNvarchar { get; set; }
+        public string dataNText { get; set; }
+
+    }
+}

--- a/src/Our.Umbraco.HealthChecks/Our.Umbraco.HealthChecks.csproj
+++ b/src/Our.Umbraco.HealthChecks/Our.Umbraco.HealthChecks.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -210,6 +210,7 @@
     <Compile Include="Checks\Azure\AzureTempStorageCheck.cs" />
     <Compile Include="Checks\Config\PostProcessorCheck.cs" />
     <Compile Include="Checks\DataIntegrity\ContentVersionsCheck.cs" />
+    <Compile Include="Checks\Data\UrlDomainHealthcheck.cs" />
     <Compile Include="Checks\Media\MediaIntegrityCheck.cs" />
     <Compile Include="Checks\Security\ClientDependencyVersionCheck.cs" />
     <Compile Include="Checks\Security\HstsCheck.cs" />
@@ -219,6 +220,8 @@
     <Compile Include="Checks\SEO\XmlSitemapCheck.cs" />
     <Compile Include="Checks\SEO\LoremIpsumCheck.cs" />
     <Compile Include="Checks\Config\ExamineRebuildOnStartCheck.cs" />
+    <Compile Include="Controllers\UrlDomainReportController.cs" />
+    <Compile Include="Models\PropertyDataDetails.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Find instances of a 'non live' domain that has crept in pre production, usually by the UrlPicker hardcoding the whole preview domain in a link when picked by the editor before production.

You can specify the domains in a comma delimited list in appsettings:
Our.Umbraco.Healthchecks.UrlPickerDomains

otherwise it will default to search for localhost